### PR TITLE
Update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ composer.lock
 phpunit.xml
 vendor
 reports
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 phpunit.xml
 vendor
 reports
+.idea

--- a/README.md
+++ b/README.md
@@ -1,14 +1,36 @@
-# websocket-server
+# Websocket Server
 
-This package provides a WebSocket `RequestHandler` for [Amp's HTTP server](https://github.com/amphp/http-server).
+This library provides a [Request Handler] to easily handle Websocket connections using [amphp/http-server].
+
+## Installation
+
+This package can be installed as a [Composer] dependency.
+
+```
+composer require amphp/websocket-server
+```
+
+> Currently this library is undergoing a RC phase on a push to 2.0! Please check out the 2.0 RC releases
+
+## Documentation
+
+The documentation for this library is currently a work in progress. Pull Requests to improve the documentation 
+are always welcome!
+
+
+## Requirements
+
+- PHP 7.0+
 
 ## Example
 
 ```php
 <?php
 
-// Note that this example requires amphp/http-server-router,
-// amphp/http-server-static-content and amphp/log to be installed.
+// Note that this example requires:
+// amphp/http-server-router,
+// amphp/http-server-static-content
+// amphp/log
 
 use Amp\Http\Server\Request;
 use Amp\Http\Server\Response;
@@ -18,31 +40,34 @@ use Amp\Http\Server\StaticContent\DocumentRoot;
 use Amp\Log\ConsoleFormatter;
 use Amp\Log\StreamHandler;
 use Amp\Loop;
-use Amp\Socket;
-use Amp\Websocket\Client;
+use Amp\Promise;use Amp\Socket;
+use Amp\Success;use Amp\Websocket\Client;
 use Amp\Websocket\Message;
 use Amp\Websocket\Server\Websocket;
 use Monolog\Logger;
 use function Amp\ByteStream\getStdout;
+use function Amp\call;
 
 require __DIR__ . '/vendor/autoload.php';
 
 $websocket = new class extends Websocket {
-    public function onHandshake(Request $request, Response $response): Response
+    public function onHandshake(Request $request, Response $response): Promise
     {
         if (!\in_array($request->getHeader('origin'), ['http://localhost:1337', 'http://127.0.0.1:1337', 'http://[::1]:1337'], true)) {
             $response->setStatus(403);
         }
 
-        return $response;
+        return new Success($response);
     }
 
-    public function onConnection(Client $client, Request $request): \Generator
+    public function onConnect(Client $client, Request $request, Response $response): Promise
     {
-        while ($message = yield $client->receive()) {
-            \assert($message instanceof Message);
-            $this->broadcast(\sprintf('%d: %s', $client->getId(), yield $message->buffer()));
-        }
+        return call(function() use($client) {
+            while ($message = yield $client->receive()) {
+                \assert($message instanceof Message);
+                $this->broadcast(\sprintf('%d: %s', $client->getId(), yield $message->buffer()));
+            }
+        });  
     }
 };
 
@@ -66,3 +91,7 @@ Loop::run(function () use ($server) {
     yield $server->start();
 });
 ```
+
+[amphp/http-server]: https://github.com/amphp/http-server
+[Composer]: https://getcomposer.org
+[Request Handler]: https://amphp.org/http-server/classes/request-handler

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # Websocket Server
 
-This library provides a [Request Handler] to easily handle Websocket connections using [amphp/http-server].
+This library provides a [Request Handler](https://amphp.org/http-server/classes/request-handler) to easily handle Websocket 
+connections using [amphp/http-server](https://github.com/amphp/http-server).
 
 ## Installation
 
-This package can be installed as a [Composer] dependency.
+This package can be installed as a [Composer](https://getcomposer.org) dependency.
 
 ```
 composer require amphp/websocket-server
@@ -92,7 +93,3 @@ Loop::run(function () use ($server) {
     yield $server->start();
 });
 ```
-
-[amphp/http-server]: https://github.com/amphp/http-server
-[Composer]: https://getcomposer.org
-[Request Handler]: https://amphp.org/http-server/classes/request-handler

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ composer require amphp/websocket-server
 The documentation for this library is currently a work in progress. Pull Requests to improve the documentation 
 are always welcome!
 
-
 ## Requirements
 
 - PHP 7.0+
@@ -40,8 +39,10 @@ use Amp\Http\Server\StaticContent\DocumentRoot;
 use Amp\Log\ConsoleFormatter;
 use Amp\Log\StreamHandler;
 use Amp\Loop;
-use Amp\Promise;use Amp\Socket;
-use Amp\Success;use Amp\Websocket\Client;
+use Amp\Promise;
+use Amp\Socket;
+use Amp\Success;
+use Amp\Websocket\Client;
 use Amp\Websocket\Message;
 use Amp\Websocket\Server\Websocket;
 use Monolog\Logger;

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ This package can be installed as a [Composer] dependency.
 composer require amphp/websocket-server
 ```
 
-> Currently this library is undergoing a RC phase on a push to 2.0! Please check out the 2.0 RC and let us know if you 
-> have any feedback.
+> Currently this library is undergoing a RC phase on a push to 2.0! Please check out the 2.0 RC and let us know if you have any feedback.
 
 ## Documentation
 
@@ -28,7 +27,7 @@ are always welcome!
 <?php
 
 // Note that this example requires:
-// amphp/http-server-router,
+// amphp/http-server-router
 // amphp/http-server-static-content
 // amphp/log
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This package can be installed as a [Composer] dependency.
 composer require amphp/websocket-server
 ```
 
-> Currently this library is undergoing a RC phase on a push to 2.0! Please check out the 2.0 RC releases
+> Currently this library is undergoing a RC phase on a push to 2.0! Please check out the 2.0 RC and let us know if you 
+> have any feedback.
 
 ## Documentation
 
@@ -19,7 +20,7 @@ are always welcome!
 
 ## Requirements
 
-- PHP 7.0+
+- PHP 7.1+
 
 ## Example
 
@@ -52,7 +53,7 @@ use function Amp\call;
 require __DIR__ . '/vendor/autoload.php';
 
 $websocket = new class extends Websocket {
-    public function onHandshake(Request $request, Response $response): Promise
+    public function handleHandshake(Request $request, Response $response): Promise
     {
         if (!\in_array($request->getHeader('origin'), ['http://localhost:1337', 'http://127.0.0.1:1337', 'http://[::1]:1337'], true)) {
             $response->setStatus(403);
@@ -61,7 +62,7 @@ $websocket = new class extends Websocket {
         return new Success($response);
     }
 
-    public function onConnect(Client $client, Request $request, Response $response): Promise
+    public function handleClient(Client $client, Request $request, Response $response): Promise
     {
         return call(function() use($client) {
             while ($message = yield $client->receive()) {

--- a/src/Websocket.php
+++ b/src/Websocket.php
@@ -64,14 +64,15 @@ abstract class Websocket implements RequestHandler, ServerObserver
      * If a websocket application doesn't wish to impose any special constraints on the
      * handshake it doesn't have to do anything in this method (other than return the
      * given Response object) and all handshakes will be automatically accepted.
-     * This method provides an opportunity to set application-specific headers on the
-     * websocket response.
+     * This method provides an opportunity to set application-specific headers and/or
+     * cookies on the websocket response.
      *
      * @param Request  $request The HTTP request that instigated the handshake
      * @param Response $response The switching protocol response for adding headers, etc.
      *
-     * @return Promise<Response> Resolve with the given response to accept the connection
-     *     or resolve with a new Response object to deny the connection.
+     * @return Promise<Response> Resolve the Promise with a Response set to a status code
+     *                           other than {@link Status::SWITCHING_PROTOCOLS} to deny the
+     *                           handshake Request.
      */
     abstract protected function handleHandshake(Request $request, Response $response): Promise;
 

--- a/src/Websocket.php
+++ b/src/Websocket.php
@@ -61,11 +61,15 @@ abstract class Websocket implements RequestHandler, ServerObserver
 
     /**
      * Respond to websocket handshake requests.
+     *
      * If a websocket application doesn't wish to impose any special constraints on the
      * handshake it doesn't have to do anything in this method (other than return the
      * given Response object) and all handshakes will be automatically accepted.
-     * This method provides an opportunity to set application-specific headers and/or
-     * cookies on the websocket response.
+     *
+     * This method provides an opportunity to set application-specific headers, including
+     * cookies, on the websocket response. Although any non-101 status code can be used
+     * to reject the websocket connection it is generally recommended to use a 4xx status
+     * code that is descriptive of why the handshake was rejected.
      *
      * @param Request  $request The HTTP request that instigated the handshake
      * @param Response $response The switching protocol response for adding headers, etc.


### PR DESCRIPTION
- Updates the README to be formatted more generally in-line with the
primary amphp/amp package.

- Updates the examples the README to properly return a Promise and use
appropriate method names.

---

I also would like to have a clarifying question around the documentation on `Websocket::onHandshake`, specifically the `@return` documentation:

```
@return Promise<Response> Resolve with the given response to accept the connection or resolve with a new Response object to deny the connection.
```

This phrasing implies that  a brand new Response instance needs to be created to deny the connection. However, the example in the README, and I believe the more intuitive API, is for any non-2XX response to deny the connection. I am unsure as to the exact semantics here but I would like to either clarify the Websocket docblocks or the example to be consistent.